### PR TITLE
日本語フィルタのON/OFF機能をポップアップ画面として作成する

### DIFF
--- a/hoyolab/content.js
+++ b/hoyolab/content.js
@@ -25,7 +25,8 @@ function callback(mutations) {
   const elements = document.getElementsByClassName('mhy-article-card');
 
   for (let i = 0; i < elements.length; i++) {
-    const titleHeads = elements[i].getElementsByClassName('mhy-article-card__title');
+    const titleHeads = elements[i]
+      .getElementsByClassName('mhy-article-card__title');
     const title = titleHeads[0].innerText;
 
     if (!includeJa(title))
@@ -35,9 +36,7 @@ function callback(mutations) {
 
 const mutationObserver = new MutationObserver(callback);
 const target = document.body;
-const option = {
-  childList: true, subtree: true
-};
+const option = { childList: true, subtree: true };
 
 chrome.runtime.sendMessage({ method: 'getItem' }, (response) => {
   const jaFilterJson = response.value;
@@ -45,21 +44,22 @@ chrome.runtime.sendMessage({ method: 'getItem' }, (response) => {
 
   if (jaFilter.enabled) {
     mutationObserver.observe(target, option);
-    console.log('Japanese language filter enabled.')
   } else {
     mutationObserver.disconnect();
-    console.log('Japanese language filter disabled.')
   }
 });
 
 chrome.runtime.onMessage.addListener((request, sender) => {
+  chrome.runtime.sendMessage({
+    method: 'setItem',
+    value: JSON.stringify({ enabled: request.jaFilterEnabled })
+  });
+
   if (request.jaFilterEnabled) {
-    chrome.runtime.sendMessage({ method: 'setItem', value: JSON.stringify({ enabled: true }) });
     mutationObserver.observe(target, option);
-    console.log('Japanese language filter enabled.')
+    console.log('Japanese language filter enabled.');
   } else {
-    chrome.runtime.sendMessage({ method: 'setItem', value: JSON.stringify({ enabled: false }) });
     mutationObserver.disconnect();
-    console.log('Japanese language filter disabled.')
+    console.log('Japanese language filter disabled.');
   }
 });

--- a/hoyolab/content.js
+++ b/hoyolab/content.js
@@ -14,7 +14,7 @@ function includeJa(text) {
       return true;
     if (regexKanji.test(text))
       return true;
-    return false;      
+    return false;
   } catch (error) {
     console.error(error);
     return true;
@@ -38,14 +38,28 @@ const target = document.body;
 const option = {
   childList: true, subtree: true
 };
-mutationObserver.observe(target, option);
+
+chrome.runtime.sendMessage({ method: 'getItem' }, (response) => {
+  const jaFilterJson = response.value;
+  const jaFilter = jaFilterJson ? JSON.parse(jaFilterJson) : { enabled: true };
+
+  if (jaFilter.enabled) {
+    mutationObserver.observe(target, option);
+    console.log('Japanese language filter enabled.')
+  } else {
+    mutationObserver.disconnect();
+    console.log('Japanese language filter disabled.')
+  }
+});
 
 chrome.runtime.onMessage.addListener((request, sender) => {
   if (request.jaFilterEnabled) {
+    chrome.runtime.sendMessage({ method: 'setItem', value: JSON.stringify({ enabled: true }) });
     mutationObserver.observe(target, option);
-    console.log("Japanese language filter enabled.")
+    console.log('Japanese language filter enabled.')
   } else {
+    chrome.runtime.sendMessage({ method: 'setItem', value: JSON.stringify({ enabled: false }) });
     mutationObserver.disconnect();
-    console.log("Japanese language filter disabled.")
+    console.log('Japanese language filter disabled.')
   }
 });

--- a/hoyolab/event.js
+++ b/hoyolab/event.js
@@ -1,30 +1,12 @@
-chrome.runtime.onInstalled.addListener(function () {
-  const parentMenu = chrome.contextMenus.create({
-    type: "normal",
-    id: "parent",
-    title: "HoYoLAB日本語フィルター"
-  });
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  const key = 'ja_filter';
 
-  chrome.contextMenus.create({
-    parentId: parentMenu,
-    type: "radio",
-    id: "true",
-    title: "ON",
-    checked: true
-  });
-
-  chrome.contextMenus.create({
-    parentId: parentMenu,
-    type: "radio",
-    id: "false",
-    title: "OFF"
-  });
-});
-
-chrome.contextMenus.onClicked.addListener(function (item) {
-  const sendData = { jaFilterEnabled: item.menuItemId.toLowerCase() === 'true' };
-  function sendMessage(tabs) {
-    chrome.tabs.sendMessage(tabs[0].id, sendData);
+  if (request.method === 'getItem') {
+    sendResponse({value: localStorage.getItem(key)});
+    return;
   }
-  chrome.tabs.query({ active: true, currentWindow: true }, sendMessage);
+  if (request.method === 'setItem') {
+    localStorage.setItem(key, request.value);
+    return;
+  }
 });

--- a/hoyolab/event.js
+++ b/hoyolab/event.js
@@ -2,7 +2,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   const key = 'ja_filter';
 
   if (request.method === 'getItem') {
-    sendResponse({value: localStorage.getItem(key)});
+    sendResponse({ value: localStorage.getItem(key) });
     return;
   }
   if (request.method === 'setItem') {

--- a/hoyolab/manifest.json
+++ b/hoyolab/manifest.json
@@ -6,7 +6,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://www.hoyolab.com/home*"
+        "https://www.hoyolab.com/*"
       ],
       "js": [
         "content.js"
@@ -19,8 +19,11 @@
     ],
     "persistent": false
   },
+  "browser_action": {
+    "default_popup": "popup.html"
+  },
   "permissions": [
-    "contextMenus",
-    "activeTab"
+    "tabs",
+    "storage"
   ]
 }

--- a/hoyolab/popup.css
+++ b/hoyolab/popup.css
@@ -1,0 +1,15 @@
+.main {
+  width: 200px;
+}
+
+.radio {
+  display: inline-block;
+}
+
+.radio > input {
+  cursor: pointer;
+}
+
+.radio > label {
+  cursor: pointer;
+}

--- a/hoyolab/popup.html
+++ b/hoyolab/popup.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <title>HoYoLab language filter</title>
+  <link rel="stylesheet" href="popup.css">
+</head>
+
+<body>
+  <div class="main">
+    <p>HoYoLab 日本語フィルター</p>
+    <div class="radio">
+      <input type="radio" id="jaFilterEnabled" name="jaFilter" value="true">
+      <label for="jaFilterEnabled">ON</label>
+      <input type="radio" id="jaFilterDisabled" name="jaFilter" value="false">
+      <label for="jaFilterDisabled">OFF</label>
+    </div>
+  </div>
+  <script src="popup.js"></script>
+</body>
+
+</html>

--- a/hoyolab/popup.js
+++ b/hoyolab/popup.js
@@ -22,11 +22,12 @@ window.onload = () => {
 
     const mainElement = document.getElementsByClassName('main')[0];
     const messageElement = document.createElement('p');
-    const messageContent = document.createTextNode('HoYoLABのページを開いた状態で操作ください。');
+    const messageContent = document
+      .createTextNode('HoYoLABのページを開いた状態で操作ください。');
     messageElement.appendChild(messageContent);
     mainElement.appendChild(messageElement);
 
-    document.querySelectorAll('input').forEach( e => e.disabled = true );
+    document.querySelectorAll('input').forEach(e => e.disabled = true);
   });
 
   // ボタン操作によるコールバック用のイベントを登録する。
@@ -34,7 +35,9 @@ window.onload = () => {
     radio.addEventListener('change', (event) => {
       const filterEnabled = event.target.value.toLowerCase() === 'true';
 
-      localStorage.setItem('ja_filter', JSON.stringify({ enabled: filterEnabled }));
+      localStorage.setItem(
+        'ja_filter', JSON.stringify({ enabled: filterEnabled })
+      );
 
       const sendData = { jaFilterEnabled: filterEnabled };
       function sendMessage(tabs) {

--- a/hoyolab/popup.js
+++ b/hoyolab/popup.js
@@ -1,0 +1,46 @@
+window.onload = () => {
+  // LocalStorage上の設定を参照し、ボタンの状態を変更する。
+  const jaFilterJson = localStorage.getItem('ja_filter');
+  const jaFilter = jaFilterJson ? JSON.parse(jaFilterJson) : { enabled: true };
+
+  if (jaFilter.enabled) {
+    const radio = document.getElementById('jaFilterEnabled');
+    radio.checked = true;
+  } else {
+    const radio = document.getElementById('jaFilterDisabled');
+    radio.checked = true;
+  }
+
+  // HoYoLABのページを開いていない（拡張機能が有効なページ上ではない）場合、操作をさせない。
+  // 好き勝手に操作をさせると、有効／無効の設定と実際の状態がズレるため。
+  // ただ、複数のタブを開いて一方のタブで設定を変更しても、別タブの状態は変わらないので結局ズレることはある。
+  // ここらへん何かうまいこと同期させる方法があれば改善してもらいたい・・・。
+  chrome.tabs.query({ 'active': true, 'lastFocusedWindow': true }, tabs => {
+    const url = tabs[0].url;
+    if (url.startsWith('https://www.hoyolab.com/'))
+      return;
+
+    const mainElement = document.getElementsByClassName('main')[0];
+    const messageElement = document.createElement('p');
+    const messageContent = document.createTextNode('HoYoLABのページを開いた状態で操作ください。');
+    messageElement.appendChild(messageContent);
+    mainElement.appendChild(messageElement);
+
+    document.querySelectorAll('input').forEach( e => e.disabled = true );
+  });
+
+  // ボタン操作によるコールバック用のイベントを登録する。
+  document.getElementsByName('jaFilter').forEach((radio) => {
+    radio.addEventListener('change', (event) => {
+      const filterEnabled = event.target.value.toLowerCase() === 'true';
+
+      localStorage.setItem('ja_filter', JSON.stringify({ enabled: filterEnabled }));
+
+      const sendData = { jaFilterEnabled: filterEnabled };
+      function sendMessage(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, sendData);
+      }
+      chrome.tabs.query({ active: true, currentWindow: true }, sendMessage);
+    });
+  });
+}


### PR DESCRIPTION
メニュー形式だといろいろと制御が困難だったのでポップアップ形式の設定画面に変更します。

![image](https://user-images.githubusercontent.com/57448478/133940359-c8a81eda-65ae-42c8-8b3b-99e4ae995e64.png)

設定をLocalStorage上に保存することで、状態がズレるバグのような動きも軽減されています。

ただ、HoYoLabのページを開く → 別タブでもう一つHoYoLabのページを開いてボタンを操作する → タブを切り替えて戻ってくると、設定の表示と内部の状態がズレますが、あまり変な使い方しないでくださいということで個人的には許容したいところ（一応画面を更新すれば設定に合わせて状態がリセットされますし）。
